### PR TITLE
Fix k anonymity

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -93,12 +93,12 @@ def force_k(values: pd.Series, value_type: str, k: int):
     elif value_type == 'category':
         k_fulfilled = df['values'].value_counts(dropna=False).loc[lambda x: x >= k]
         k_not_fulfilled = df['values'].value_counts(dropna=False).loc[lambda x: x < k]
-        if len(k_not_fulfilled) == 1 or (sum(k_not_fulfilled) < k and sum(k_not_fulfilled) > 0):
+        if len(k_not_fulfilled) == 1 or (k > sum(k_not_fulfilled) > 0):
             # if we do have only one category that does not fulfill k,
             # or several categories where their sum does not fulfill k either,
-            # we merge these values with the smallest valid category (second to last)
+            # we merge these values with the smallest valid category
             # and call it 'Other'
-            smallest_valid_category = df['values'].value_counts(dropna=False).index.tolist()[-2]
+            smallest_valid_category = k_fulfilled.index.tolist()[-1]
             df['Other'] = df['values'].apply(lambda x: x if x in k_fulfilled
                                              and x is not smallest_valid_category else 'Other')
         else:

--- a/pre_tests.py
+++ b/pre_tests.py
@@ -18,7 +18,7 @@ class TestDataProcessing(unittest.TestCase):
         print(f"Test k_anonymity with k={k}")
         int_values = pd.Series([1, 1, 1, 1, 3, 3, 3, 5, 5, 5, 5, 5])
         float_values = pd.Series([0.5, 0.7, 1.3, 1.3, 0.8, 1.4, 0.5, 0.7, 1.2, 1.1, 1.2, 1.2, 1.2, 1.0])
-        cat_values = pd.Series(['L', 'R', 'L', 'B', 'B', 'B', 'R', 'R', 'R'])
+        cat_values = pd.Series(['L', 'R', 'L', 'B', 'B', 'B', 'L', 'R', 'R', 'R', 'F', 'I'])
         cat_values_nan = pd.Series(['L', 'R', 'L', None, 'B', 'B', None, 'B', 'R', None, 'R', 'R'])
         year_values = pd.Series([2010, 2010, 2011, 2011, 2012, 2012, 2012, 2013, 2014])
         for values, data_type in zip([int_values, float_values, cat_values, cat_values_nan, year_values],


### PR DESCRIPTION
Fixes bug in k-anonymity for categories: 

If there was more than 1 category that did not fullfill k, the merging was done incorrectly, i.e. for k=3: 
input = ['L', 'R', 'L', 'B', 'B', 'B', 'L', 'R', 'R', 'R', 'F', 'I'] would let to: 
output = ['L', 'R', 'L', 'B', 'B', 'B', 'L', 'R', 'R', 'R', 'Other', 'Other']
which still does not fulfill k. 
Now, it will result in: 
output = ['L', 'R', 'L', 'Other', 'Other', 'Other', 'L', 'R', 'R', 'R', 'Other', 'Other'] 

Note: You can also write and test new examples in pre_test.py to verify. 